### PR TITLE
Set worker domain, added concurrency to TaskRunner, change options in TaskRunner/TaskManager

### DIFF
--- a/src/task/Poller.ts
+++ b/src/task/Poller.ts
@@ -1,13 +1,5 @@
 import { ConductorLogger } from "../common";
-
-const noopLogger: ConductorLogger = {
-  //eslint-disable-next-line
-  debug: (...args: any) => {},
-  //eslint-disable-next-line
-  info: (...args: any) => {},
-  //eslint-disable-next-line
-  error: (...args: any) => {},
-};
+import { noopLogger } from "./helpers";
 
 interface PollerOptions {
   pollInterval?: number;

--- a/src/task/Poller.ts
+++ b/src/task/Poller.ts
@@ -1,0 +1,121 @@
+import { ConductorLogger } from "../common";
+
+const noopLogger: ConductorLogger = {
+  //eslint-disable-next-line
+  debug: (...args: any) => {},
+  //eslint-disable-next-line
+  info: (...args: any) => {},
+  //eslint-disable-next-line
+  error: (...args: any) => {},
+};
+
+interface PollerOptions {
+  pollInterval?: number;
+  concurrency: number;
+}
+
+export class Poller {
+  private concurrentCalls: Array<{
+    promise: Promise<void>;
+    stop: () => void;
+  }> = [];
+  private pollFunction: () => Promise<void> = async () => {};
+  private isPolling = false;
+  options: PollerOptions = {
+    pollInterval: 1000,
+    concurrency: 1,
+  };
+  logger: ConductorLogger = noopLogger;
+
+  constructor(
+    pollFunction: () => Promise<void>,
+    pollerOptions?: Partial<PollerOptions>,
+    logger?: ConductorLogger
+  ) {
+    this.pollFunction = pollFunction;
+    this.options = { ...this.options, ...pollerOptions };
+    this.logger = logger || noopLogger;
+  }
+
+  /**
+   * Starts polling for work
+   */
+  startPolling = () => {
+    if (this.isPolling) {
+      throw new Error("Runner is already started");
+    }
+
+    return this.poll();
+  };
+
+  /**
+   * Stops Polling for work
+   */
+  stopPolling = () => {
+    this.isPolling = false;
+    this.concurrentCalls.forEach((call) => call.stop());
+  };
+
+ /**
+  * adds or shuts down concurrent calls based on the concurrency setting
+  * @param concurrency 
+  */ 
+  private updateConcurrency(concurrency: number) {
+    if (concurrency > 0 && concurrency !== this.options.concurrency) {
+      if (concurrency < this.options.concurrency) {
+        const result = this.concurrentCalls.splice(
+          0,
+          this.options.concurrency - concurrency
+        );
+        result.forEach((call) => {
+          call.stop();
+          this.logger.debug("stopping some spawned calls");
+        });
+      } else {
+        for (let i = 0; i < concurrency - this.options.concurrency; i++) {
+          this.concurrentCalls.push(this.singlePoll());
+          this.logger.debug("spawning additional poll calls");
+        }
+      }
+      this.options.concurrency = concurrency;
+    }
+  }
+
+  updateOptions(options: Partial<PollerOptions>) {
+    const newOptions = { ...this.options, ...options };
+    this.updateConcurrency(newOptions.concurrency);
+    this.options = newOptions;
+  }
+
+  private poll = async () => {
+    if (!this.isPolling) {
+      this.isPolling = true;
+      for (let i = 0; i < this.options.concurrency; i++) {
+        this.concurrentCalls.push(this.singlePoll());
+      }
+    }
+  };
+
+  private singlePoll = () => {
+    let poll = this.isPolling;
+    let timeout: NodeJS.Timeout;
+    const pollingCall = async () => {
+      while (poll) {
+        await this.pollFunction();
+        await new Promise(
+          (r) =>
+            (timeout = setTimeout(() => r(true), this.options.pollInterval))
+        );
+      }
+    };
+
+    return {
+      promise: pollingCall(),
+      stop: () => {
+        clearTimeout(timeout);
+        poll = false;
+        this.logger.debug("stopping single poll call");
+      },
+    };
+  };
+}

--- a/src/task/TaskManager.ts
+++ b/src/task/TaskManager.ts
@@ -1,4 +1,4 @@
-import os from "os";
+import os, { type } from "os";
 import {
   TaskRunner,
   TaskRunnerOptions,
@@ -9,20 +9,22 @@ import { ConductorLogger, DefaultLogger } from "../common";
 import { ConductorWorker } from "./Worker";
 import { ConductorClient } from "../common/open-api";
 
+export type TaskManagerOptions = TaskRunnerOptions;
+
 export interface TaskManagerConfig {
   logger?: ConductorLogger;
-  options?: Partial<TaskRunnerOptions>;
+  options?: Partial<TaskManagerOptions>;
   onError?: TaskErrorHandler;
 }
 
-const defaultManagerOptions: Required<TaskRunnerOptions> = {
+const defaultManagerOptions: Required<TaskManagerOptions> = {
   workerID: "",
   pollInterval: 1000,
   domain: undefined,
   concurrency: 1,
 };
 
-function workerId(options: Partial<TaskRunnerOptions>) {
+function workerId(options: Partial<TaskManagerOptions>) {
   return options.workerID ?? os.hostname();
 }
 
@@ -35,7 +37,7 @@ export class TaskManager {
   private readonly logger: ConductorLogger;
   private readonly errorHandler: TaskErrorHandler;
   private workers: Array<ConductorWorker>;
-  private readonly taskManageOptions: Required<TaskRunnerOptions>;
+  private readonly taskManageOptions: Required<TaskManagerOptions>;
 
   constructor(
     client: ConductorClient,
@@ -61,7 +63,7 @@ export class TaskManager {
 
   private workerManagerWorkerOptions = (
     worker: ConductorWorker
-  ): Required<TaskRunnerOptions> => {
+  ): Required<TaskManagerOptions> => {
     return {
       ...this.taskManageOptions,
       concurrency: worker.concurrency ?? this.taskManageOptions.concurrency,
@@ -73,7 +75,7 @@ export class TaskManager {
    * new options will get merged to existing options
    * @param options new options to update polling options
    */
-  updatePollingOptions = (options: Partial<TaskRunnerOptions>) => {
+  updatePollingOptions = (options: Partial<TaskManagerOptions>) => {
     this.workers.forEach((worker) => {
       const newOptions = {
         ...this.workerManagerWorkerOptions(worker),

--- a/src/task/TaskManager.ts
+++ b/src/task/TaskManager.ts
@@ -1,4 +1,4 @@
-import os, { type } from "os";
+import os from "os";
 import {
   TaskRunner,
   TaskRunnerOptions,

--- a/src/task/TaskRunner.ts
+++ b/src/task/TaskRunner.ts
@@ -77,6 +77,15 @@ export class TaskRunner {
     this.isPolling = false;
   };
 
+  set setOptions(options: Required<TaskManagerOptions>) {
+    this.options = options;
+  }
+
+  get getOptions():TaskManagerOptions {
+    return this.options;
+  }
+
+
   poll = async () => {
     while (this.isPolling) {
       try {
@@ -84,7 +93,7 @@ export class TaskRunner {
         const task = await this.taskResource.poll(
           this.worker.taskDefName,
           workerID,
-          this.options.domain
+          this.worker.domain ?? this.options.domain,
         );
         if (task && task.taskId) {
           await this.executeTask(task);

--- a/src/task/TaskRunner.ts
+++ b/src/task/TaskRunner.ts
@@ -2,6 +2,7 @@ import { ConductorLogger } from "../common";
 import { ConductorWorker } from "./Worker";
 import { Task, TaskResourceService, TaskResult } from "../common/open-api";
 import { Poller } from "./Poller";
+import { noopLogger } from "./helpers";
 
 const DEFAULT_ERROR_MESSAGE = "An unknown error occurred";
 const MAX_RETRIES = 3;
@@ -26,15 +27,6 @@ export interface RunnerArgs {
 //eslint-disable-next-line
 export const noopErrorHandler: TaskErrorHandler = (__error: Error) => {};
 
-const noopLogger: ConductorLogger = {
-  //eslint-disable-next-line
-  debug: (...args: any) => {},
-  //eslint-disable-next-line
-  info: (...args: any) => {},
-  //eslint-disable-next-line
-  error: (...args: any) => {},
-};
-
 /**
  * Responsible for polling and executing tasks from a queue.
  *
@@ -50,7 +42,7 @@ export class TaskRunner {
   private logger: ConductorLogger;
   private options: Required<TaskRunnerOptions>;
   errorHandler: TaskErrorHandler;
-  private poller:Poller;
+  private poller: Poller;
 
   constructor({
     worker,
@@ -66,8 +58,9 @@ export class TaskRunner {
     this.errorHandler = errorHandler;
     this.poller = new Poller(
       this.pollAndExecute,
-      {concurrency:options.concurrency, pollInterval:options.pollInterval},
-      this.logger);
+      { concurrency: options.concurrency, pollInterval: options.pollInterval },
+      this.logger
+    );
   }
 
   /**
@@ -92,7 +85,6 @@ export class TaskRunner {
     this.options = newOptions;
   }
 
-
   get getOptions(): TaskRunnerOptions {
     return this.options;
   }
@@ -115,8 +107,6 @@ export class TaskRunner {
       this.errorHandler(unknownError as Error);
     }
   };
-
-
 
   updateTaskWithRetry = async (task: Task, taskResult: TaskResult) => {
     let retryCount = 0;

--- a/src/task/__tests__/Poller.test.ts
+++ b/src/task/__tests__/Poller.test.ts
@@ -16,7 +16,7 @@ describe("Poller", () => {
     expect(functionToRun).toHaveBeenCalledTimes(3);
   });
 
-  test("Should run the poll function once for each interval if concurrency is just one", async () => {
+  test("Should run the poll function twice as much. with two times the concurrency", async () => {
     const functionToRun = jest.fn();
     const poller = new Poller(
       async () => {

--- a/src/task/__tests__/Poller.test.ts
+++ b/src/task/__tests__/Poller.test.ts
@@ -1,0 +1,78 @@
+import { Poller } from "../Poller";
+import { expect, describe, test, jest } from "@jest/globals";
+
+describe("Poller", () => {
+  test("Should run the poll function once for each interval if concurrency is just one", async () => {
+    const functionToRun = jest.fn();
+    const poller = new Poller(
+      async () => {
+        functionToRun();
+      },
+      { concurrency: 1, pollInterval: 1000 }
+    );
+    poller.startPolling();
+    await new Promise((r) => setTimeout(() => r(true), 3000));
+    poller.stopPolling();
+    expect(functionToRun).toHaveBeenCalledTimes(3);
+  });
+
+  test("Should run the poll function once for each interval if concurrency is just one", async () => {
+    const functionToRun = jest.fn();
+    const poller = new Poller(
+      async () => {
+        functionToRun();
+      },
+      { concurrency: 2, pollInterval: 1000 }
+    );
+    poller.startPolling();
+    await new Promise((r) => setTimeout(() => r(true), 3000));
+    poller.stopPolling();
+    expect(functionToRun).toHaveBeenCalledTimes(6);
+  });
+  test("Should be able to change add concurrency dynamically", async () => {
+    const functionToRun = jest.fn();
+    const poller = new Poller(
+      async () => {
+        functionToRun();
+      },
+      { concurrency: 1, pollInterval: 1000 }
+    );
+    poller.startPolling();
+    await new Promise((r) => setTimeout(() => r(true), 1000));
+    poller.updateOptions({ concurrency: 2 });
+    await new Promise((r) => setTimeout(() => r(true), 2000));
+    poller.stopPolling();
+    expect(functionToRun).toHaveBeenCalledTimes(5);
+  });
+  test("Should be able to change remove concurrency dynamically", async () => {
+    const functionToRun = jest.fn();
+    const poller = new Poller(
+      async () => {
+        functionToRun();
+      },
+      { concurrency: 2, pollInterval: 1000 }
+    );
+    poller.startPolling();
+    await new Promise((r) => setTimeout(() => r(true), 1000));
+    poller.updateOptions({ concurrency: 1 });
+    await new Promise((r) => setTimeout(() => r(true), 2000));
+    poller.stopPolling();
+    expect(functionToRun).toHaveBeenCalledTimes(4);
+  });
+  
+  test("Should be able to change the pollInterval", async () => {
+    const functionToRun = jest.fn();
+    const poller = new Poller(
+      async () => {
+        functionToRun();
+      },
+      { concurrency: 1, pollInterval: 1000 }
+    );
+    poller.startPolling();
+    await new Promise((r) => setTimeout(() => r(true), 1000));
+    poller.updateOptions({ pollInterval: 500 });
+    await new Promise((r) => setTimeout(() => r(true), 2000));
+    poller.stopPolling();
+    expect(functionToRun).toHaveBeenCalledTimes(5);
+  });
+});

--- a/src/task/helpers.ts
+++ b/src/task/helpers.ts
@@ -1,0 +1,11 @@
+
+import type { ConductorLogger } from "../common";
+
+export const noopLogger: ConductorLogger = {
+  //eslint-disable-next-line
+  debug: (...args: any) => {},
+  //eslint-disable-next-line
+  info: (...args: any) => {},
+  //eslint-disable-next-line
+  error: (...args: any) => {},
+};


### PR DESCRIPTION
- Adds the ability to set domain in the worker. The domain passed in the worker will have precedence over the one passed to the runner (either TaskRunner[single worker] or TaskManager[multiple workers]).
- Adds support for "concurrency" to TaskRunner. Moved concurrency to TaskRunner. SingleWorkers have that option too but before this the option was doing nothing.
- Adds the ability to change the options on a running TaskRunner/TaskManager so for a TaskRunner that is currently running with a concurrency set, you can now change the options using the updateOptions methods.
- Refactor: Abstracted Poller to its own class. Added tests to the Poller class
